### PR TITLE
:bug: Avoid import-time Svelte generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,37 @@ To get started, install the package from npm:
 npm install sapper-i18n-sync
 ```
 
-To create a `locales` directory from a remote git repository:
+Create a script in your Sapper app, for example `scripts/sync-i18n.js`:
 
-```ts
-import { generateLocales } from "sapper-i18n-sync";
-generateLocales({
-  gitRepo: "https://github.com/koj-co/i18n",
-  path: "locales",
-})
+```js
+const { generateLocales, generateSvelte } = require("sapper-i18n-sync");
+
+async function main() {
+  await generateLocales({
+    gitRepo: "https://github.com/koj-co/i18n",
+    path: "locales",
+  });
+
+  await generateSvelte();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 ```
 
-Then, generate:
+Then add it to your app's `package.json`:
 
-```ts
-import { generateSvelte } from "sapper-i18n-sync";
-generateSvelte();
+```json
+{
+  "scripts": {
+    "sync:i18n": "node scripts/sync-i18n.js"
+  }
+}
 ```
+
+Run `npm run sync:i18n` before your Sapper build/export step. The script clones the remote repository's `locales` directory into your app, then generates localized Svelte components and routes from `src/_components`, `src/_routes`, and `src/_generated`.
 
 ## 📄 License
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run build && node test/import-no-side-effects.js"
   },
   "repository": {
     "type": "git",

--- a/src/generate-svelte.ts
+++ b/src/generate-svelte.ts
@@ -190,4 +190,3 @@ export const generateSvelte = async () => {
     await remove(join(".", "src", "routes", language, "generated"));
   }
 };
-generateSvelte();

--- a/test/import-no-side-effects.js
+++ b/test/import-no-side-effects.js
@@ -1,0 +1,32 @@
+const { spawnSync } = require("child_process");
+const { mkdtempSync, rmSync } = require("fs");
+const { tmpdir } = require("os");
+const { join } = require("path");
+
+const projectRoot = join(__dirname, "..");
+const tempDir = mkdtempSync(join(tmpdir(), "sapper-i18n-sync-import-"));
+const script = `
+process.on("unhandledRejection", (error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+require(${JSON.stringify(join(projectRoot, "dist"))});
+setTimeout(() => process.exit(0), 250);
+`;
+
+const child = spawnSync(process.execPath, ["-e", script], {
+  cwd: tempDir,
+  encoding: "utf8",
+});
+rmSync(tempDir, { recursive: true, force: true });
+const output = `${child.stdout || ""}${child.stderr || ""}`;
+
+if (child.status !== 0) {
+  console.error(output);
+  process.exit(child.status || 1);
+}
+
+if (/Generating components and routes|ENOENT/.test(output)) {
+  console.error(output);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- stop `generate-svelte` from running automatically when the package is imported
- add a regression test that imports the built package from a clean directory with no `locales` folder
- expand the README with a concrete `scripts/sync-i18n.js` setup and package script

## Test plan
- `npm ci`
- `npm run build`
- `npm test`

Closes #3
